### PR TITLE
Navigation Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,13 @@ It also provide a small set of primitive navigational views out-of-the-box, but 
       }
     ```
 
-1. Add the navigation reducer to the store.
+1. Add the `NavigationReducer` and `NavigationMiddleware` to the store.
     ```swift
-      Store(state: AppState(), reducer: AppReducer() + NavigationReducer())
+      Store(
+        state: AppState(),
+        reducer: AppReducer() + NavigationReducer(),
+        middleware: NavigationMiddleware()
+      )
     ```
 
 1. Provide the store to the root of the application.

--- a/Sources/AppNavigation/NavigationAction.swift
+++ b/Sources/AppNavigation/NavigationAction.swift
@@ -110,6 +110,10 @@ extension NavigationAction {
     ActionPlan<NavigationStateRoot> { store, completed in
       let getRoute = routeGetter(forScene: sceneName, isDetail: isDetail)
       let options = store.state.navigation.options
+
+      guard let route = getRoute(store) else { return nil }
+      guard !route.completed else { return nil }
+
       return store.didChange
         .setFailureType(to: NavigationError.self)
         .timeout(options.completionTimeout, scheduler: RunLoop.main) {
@@ -152,7 +156,7 @@ extension NavigationAction {
   private static func sceneGetter(forScene sceneName: String) -> (StoreProxy<NavigationStateRoot>) -> NavigationState.Scene? {
     { store in
       guard let scene = store.state.navigation.sceneByName[sceneName] else {
-        store.send(self.setError(.sceneNotFound, message: "Scene not found for: '\(sceneName)'"))
+        store.send(self.setError(.sceneNotFound(scene: sceneName), message: "Scene not found for: '\(sceneName)'"))
         return nil
       }
       return scene

--- a/Sources/AppNavigation/NavigationAction.swift
+++ b/Sources/AppNavigation/NavigationAction.swift
@@ -45,12 +45,9 @@ extension NavigationAction {
     skipIfAncestor: Bool = false,
     animate: Bool = true
   ) -> ActionPlan<NavigationStateRoot> {
-    ActionPlan { store, completed in
+    ActionPlan { store in
       let getRoute = self.routeGetter(forScene: scene, isDetail: isDetail)
-      guard let route = getRoute(store) else {
-        completed()
-        return nil
-      }
+      guard let route = getRoute(store) else { return }
       if !route.completed {
         store.send(self.completeRouting(scene: scene, isDetail: isDetail))
       }
@@ -63,7 +60,6 @@ extension NavigationAction {
           animate: animate
         )
       )
-      return waitForRouteCompeletion(forStore: store, inScene: scene, isDetail: isDetail, completed: completed)
     }
   }
 
@@ -98,6 +94,43 @@ extension NavigationAction {
     }
   }
 
+  /// Verify that a route has completed.
+  ///
+  /// If a route isn't completed in a given time range, it will timeout.
+  /// - Parameters:
+  ///   - sceneName: The route's scene.
+  ///   - isDetail: If it is the detail route.
+  /// - Returns: The AnyCancellable.
+  public static func verifyRouteCompeletion(
+    inScene sceneName: String,
+    isDetail: Bool
+  )
+    -> Action
+  {
+    ActionPlan<NavigationStateRoot> { store, completed in
+      let getRoute = routeGetter(forScene: sceneName, isDetail: isDetail)
+      let options = store.state.navigation.options
+      return store.didChange
+        .setFailureType(to: NavigationError.self)
+        .timeout(options.completionTimeout, scheduler: RunLoop.main) {
+          NavigationError.routeCompletionFailed(scene: sceneName, isDetail: isDetail)
+        }
+        .compactMap { _ in getRoute(store) }
+        .filter { $0.completed }
+        .first { _ in true }
+        .sink(
+          receiveCompletion: { completion in
+            defer { completed() }
+            if case .failure(let error) = completion {
+              store.send(self.setError(error, message: "Route completion timed out for: '\(getRoute(store)?.path ?? "")'"))
+              store.send(NavigationAction.completeRouting(scene: sceneName, isDetail: isDetail))
+            }
+          },
+          receiveValue: { _ in }
+        )
+    }
+  }
+
   /// A getter that retrieves a specific route from a scene.
   ///
   /// - Parameters:
@@ -124,42 +157,5 @@ extension NavigationAction {
       }
       return scene
     }
-  }
-
-  /// Creates a subscription that completes once an active route has finished resolving.
-  ///
-  /// If a route isn't completed in a given time range, it will timeout.
-  /// - Parameters:
-  ///   - store: The store.
-  ///   - sceneName: The route's scene.
-  ///   - isDetail: If it is the detail route.
-  ///   - completed: Called once the route is completed.
-  /// - Returns: The AnyCancellable.
-  private static func waitForRouteCompeletion(
-    forStore store: StoreProxy<NavigationStateRoot>,
-    inScene sceneName: String,
-    isDetail: Bool,
-    completed: @escaping () -> Void
-  )
-    -> AnyCancellable
-  {
-    let getRoute = routeGetter(forScene: sceneName, isDetail: isDetail)
-    let options = store.state.navigation.options
-    return store.didChange
-      .setFailureType(to: NavigationError.self)
-      .timeout(options.completionTimeout, scheduler: RunLoop.main) { NavigationError.routeCompletionFailed }
-      .compactMap { _ in getRoute(store) }
-      .filter { $0.completed }
-      .first { _ in true }
-      .sink(
-        receiveCompletion: { completion in
-          defer { completed() }
-          if case .failure(let error) = completion {
-            store.send(self.setError(error, message: "Route completion timed out for: '\(getRoute(store)?.path ?? "")'"))
-            store.send(NavigationAction.completeRouting(scene: sceneName, isDetail: isDetail))
-          }
-        },
-        receiveValue: { _ in }
-      )
   }
 }

--- a/Sources/AppNavigation/NavigationError.swift
+++ b/Sources/AppNavigation/NavigationError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public enum NavigationError: String, Error, Codable {
+public enum NavigationError: Error, Equatable {
   case unknown
   case sceneNotFound
-  case routeCompletionFailed
+  case routeCompletionFailed(scene: String, isDetail: Bool)
 }

--- a/Sources/AppNavigation/NavigationError.swift
+++ b/Sources/AppNavigation/NavigationError.swift
@@ -2,6 +2,6 @@ import Foundation
 
 public enum NavigationError: Error, Equatable {
   case unknown
-  case sceneNotFound
+  case sceneNotFound(scene: String)
   case routeCompletionFailed(scene: String, isDetail: Bool)
 }

--- a/Sources/AppNavigation/NavigationMiddleware.swift
+++ b/Sources/AppNavigation/NavigationMiddleware.swift
@@ -7,20 +7,39 @@ import SwiftUI
 /// perserve the integrity of the navigation system.
 public struct NavigationMiddleware<State>: Middleware where State: NavigationStateRoot {
 
+  /// Optional handler that controls the routes the user has access to. It can also be used
+  /// to rediret the user to different route if needed. For example, they could be redirected
+  /// to a login screen.
+  private var onNavigate: NavigateHandler?
+
   /// Triggers when completion failed. It provide the scene name and if it is the detail route.
   /// The default implementation redirects the route to the root waypoint.
-  private var onCompletionFailed: (StoreProxy<State>, String, Bool) -> Void
+  private var onError: ErrorHandler
 
   public init(
-    onCompletionFailed: @escaping (StoreProxy<State>, String, Bool) -> Void = { store, scene, isDetail in
-      store.send(NavigationAction.navigate(to: "/", isDetail: isDetail, animate: false))
-    }
+    onNavigate: NavigateHandler? = nil,
+    onError: @escaping ErrorHandler = Self.defaultErrorHandler
   ) {
-    self.onCompletionFailed = onCompletionFailed
+    self.onNavigate = onNavigate
+    self.onError = onError
   }
 
   public func run(store: StoreProxy<State>, action: Action) {
-    store.next(action)
+    if allowNavigationAction(store: store, action: action) {
+      store.next(action)
+      postActionRun(store: store, action: action)
+    }
+  }
+
+  private func allowNavigationAction(store: StoreProxy<State>, action: Action) -> Bool {
+    guard
+      let onNavigate = onNavigate,
+      case NavigationAction.beginRouting(let path, let scene, let isDetail, _, let animate) = action
+    else { return true }
+    return onNavigate(store, path, scene, isDetail, animate)
+  }
+
+  private func postActionRun(store: StoreProxy<State>, action: Action) {
     switch action {
     case NavigationAction.beginRouting(_, let scene, let isDetail, _, _):
       store.send(NavigationAction.verifyRouteCompeletion(inScene: scene, isDetail: isDetail))
@@ -33,12 +52,65 @@ public struct NavigationMiddleware<State>: Middleware where State: NavigationSta
           store.send(NavigationAction.verifyRouteCompeletion(inScene: sceneName, isDetail: true))
         }
       }
-    case NavigationAction.setError(let error, _):
-      if case .routeCompletionFailed(let scene, let isDetail) = error {
-        onCompletionFailed(store, scene, isDetail)
-      }
+    case NavigationAction.setError(let error, let message):
+      onError(store, error, message)
     default:
       break
     }
+  }
+}
+
+extension NavigationMiddleware {
+
+  /// Determine if a route is navigable by the user.
+  ///
+  /// - Parameters:
+  ///   - store: The store. It can be used to send actions within the handler.
+  ///   - path: The path of the route.
+  ///   - scene: The scene of the route..
+  ///   - isDetail: If it's the detail route..
+  ///   - animate: if the routing will animate.
+  /// - Returns: True to allow the routing or false to stop it.
+  public typealias NavigateHandler = (StoreProxy<State>, String, String, Bool, Bool) -> Bool
+
+  /// Handle navigational errors, and provide ways to recover from them.
+  ///
+  /// - Parameters:
+  ///   - store: The store. It can be used to send actions within the handler.
+  ///   - error: The navigational error.
+  ///   - message:The error message, useful for logging.
+  public typealias ErrorHandler = (StoreProxy<State>, NavigationError, String) -> Void
+
+  /// Default error handler. It redirect failed routes to the root path. It also prints any errors.
+  ///
+  /// - Parameters:
+  ///   - store: The store. It can be used to send actions within the handler.
+  ///   - error: The navigational error.
+  ///   - message:The error message, useful for logging.
+  public static func defaultErrorHandler(store: StoreProxy<State>, error: NavigationError, message: String) {
+    routeCompletionFailedErrorHandler(store: store, error: error, message: message)
+    printErrorHandler(store: store, error: error, message: message)
+  }
+
+  /// Use as an error handler to redirect failed routes to the root path.
+  ///
+  /// - Parameters:
+  ///   - store: The store. It can be used to send actions within the handler.
+  ///   - error: The navigational error.
+  ///   - message:The error message, useful for logging.
+  public static func routeCompletionFailedErrorHandler(store: StoreProxy<State>, error: NavigationError, message: String) {
+    if case .routeCompletionFailed(let scene, let isDetail) = error {
+      store.send(NavigationAction.navigate(to: "/", inScene: scene, isDetail: isDetail, animate: false))
+    }
+  }
+
+  /// Use as an error handler to print out the error messages.
+  ///
+  /// - Parameters:
+  ///   - store: The store. It can be used to send actions within the handler.
+  ///   - error: The navigational error.
+  ///   - message:The error message, useful for logging.
+  public static func printErrorHandler(store: StoreProxy<State>, error: NavigationError, message: String) {
+    print(message)
   }
 }

--- a/Sources/AppNavigation/NavigationMiddleware.swift
+++ b/Sources/AppNavigation/NavigationMiddleware.swift
@@ -1,0 +1,44 @@
+import Combine
+import Foundation
+import SwiftDux
+import SwiftUI
+
+/// Observes the navigational state to provide additional functionality andto help
+/// perserve the integrity of the navigation system.
+public struct NavigationMiddleware<State>: Middleware where State: NavigationStateRoot {
+
+  /// Triggers when completion failed. It provide the scene name and if it is the detail route.
+  /// The default implementation redirects the route to the root waypoint.
+  private var onCompletionFailed: (StoreProxy<State>, String, Bool) -> Void
+
+  public init(
+    onCompletionFailed: @escaping (StoreProxy<State>, String, Bool) -> Void = { store, scene, isDetail in
+      store.send(NavigationAction.navigate(to: "/", isDetail: isDetail, animate: false))
+    }
+  ) {
+    self.onCompletionFailed = onCompletionFailed
+  }
+
+  public func run(store: StoreProxy<State>, action: Action) {
+    store.next(action)
+    switch action {
+    case NavigationAction.beginRouting(_, let scene, let isDetail, _, _):
+      store.send(NavigationAction.verifyRouteCompeletion(inScene: scene, isDetail: isDetail))
+    case StoreAction<State>.reset:
+      store.state.navigation.sceneByName.forEach { sceneName, scene in
+        if scene.route.path != "/" {
+          store.send(NavigationAction.verifyRouteCompeletion(inScene: sceneName, isDetail: false))
+        }
+        if scene.detailRoute.path != "/" {
+          store.send(NavigationAction.verifyRouteCompeletion(inScene: sceneName, isDetail: true))
+        }
+      }
+    case NavigationAction.setError(let error, _):
+      if case .routeCompletionFailed(let scene, let isDetail) = error {
+        onCompletionFailed(store, scene, isDetail)
+      }
+    default:
+      break
+    }
+  }
+}

--- a/Sources/AppNavigation/State/NavigationState.swift
+++ b/Sources/AppNavigation/State/NavigationState.swift
@@ -14,8 +14,8 @@ public struct NavigationState: StateType {
   /// All scenes by their name.
   public var sceneByName: [String: Scene]
 
-  public var lastNavigationError: NavigationError?
-  public var lastNavigationErrorMessage: String?
+  public var lastNavigationError: NavigationError? = nil
+  public var lastNavigationErrorMessage: String? = nil
 
   public init(
     options: Options = Options(),
@@ -29,6 +29,10 @@ public struct NavigationState: StateType {
     self.sceneByName = sceneByName
     self.lastNavigationError = lastNavigationError
     self.lastNavigationErrorMessage = lastNavigationErrorMessage
+  }
+
+  public enum CodingKeys: String, CodingKey {
+    case options, sceneByName
   }
 }
 

--- a/Sources/AppNavigation/UI/RouteReader.swift
+++ b/Sources/AppNavigation/UI/RouteReader.swift
@@ -67,6 +67,7 @@ public struct RouteInfo {
   /// The full path of the current route.
   public var fullPath: String
 
+  /// The legs of the route by their parent path.
   public var legs: [String: NavigationState.RouteLeg]
 
   /// If the routing has completed.
@@ -81,10 +82,6 @@ public struct RouteInfo {
   /// The current component of the waypoint if it's active.
   public var path: String {
     waypoint.path
-  }
-
-  public var isLastLeg: Bool {
-    nextPath == fullPath
   }
 
   /// The current component of the waypoint if it's active.
@@ -103,11 +100,17 @@ public struct RouteInfo {
     return legs[nextPath]?.component
   }
 
-  func component<T>(as type: T.Type) -> T? where T: LosslessStringConvertible {
+  /// Resolve the compnent as a specific type.
+  /// - Parameter type: The type of the component.
+  /// - Returns: The resolved component.
+  public func component<T>(as type: T.Type) -> T? where T: LosslessStringConvertible {
     component.flatMap { T($0) }
   }
 
-  func nextComponent<T>(as type: T.Type) -> T? where T: LosslessStringConvertible {
+  /// Resolve the next compnent as a specific type.
+  /// - Parameter type: The type of the component.
+  /// - Returns: The resolved component.
+  public func nextComponent<T>(as type: T.Type) -> T? where T: LosslessStringConvertible {
     nextComponent.flatMap { T($0) }
   }
 }
@@ -118,9 +121,9 @@ public protocol RouteReaderView: View {
   var isDetail: Bool? { get }
 
   /// The body of the view.
-  /// - Parameter routeInfo: The current routing information.
+  /// - Parameter info: The current routing information.
   /// - Returns: The view.
-  func body(routeInfo: RouteInfo) -> Content
+  func body(info: RouteInfo) -> Content
 }
 
 extension RouteReaderView {
@@ -139,15 +142,15 @@ public protocol RouteReaderViewModifier: ViewModifier {
   /// The body of the view.
   /// - Parameters:
   ///   - content: The content to modify.
-  ///   - routeInfo: The current routing information.
+  ///   - info: The current routing information.
   /// - Returns: The view.
-  func body(content: Content, routeInfo: RouteInfo) -> RouteReaderContent
+  func body(content: Content, info: RouteInfo) -> RouteReaderContent
 }
 
 extension RouteReaderViewModifier {
   public var isDetail: Bool? { nil }
 
   public func body(content: Content) -> RouteReader<RouteReaderContent> {
-    RouteReader(isDetail: isDetail) { self.body(content: content, routeInfo: $0) }
+    RouteReader(isDetail: isDetail) { self.body(content: content, info: $0) }
   }
 }

--- a/Sources/AppNavigation/UI/Waypoint.swift
+++ b/Sources/AppNavigation/UI/Waypoint.swift
@@ -39,10 +39,10 @@ public struct Waypoint: Equatable {
     return resolveSceneState(in: state)?.route
   }
 
-  /// Get the next RouteInfo object for the provided component.
+  /// Get the next Waypoint object for the provided component.
   ///
   /// - Parameter component: The next component.
-  /// - Returns: A new `RouteInfo`
+  /// - Returns: A new `Waypoint`
   public func next<T>(with component: T) -> Waypoint where T: LosslessStringConvertible {
     return Waypoint(
       sceneName: sceneName,

--- a/Sources/AppNavigation/UI/WaypointResolver.swift
+++ b/Sources/AppNavigation/UI/WaypointResolver.swift
@@ -37,26 +37,26 @@ public struct WaypointResolver<Content>: RouteReaderView where Content: View {
     self.content = content
   }
 
-  public func body(routeInfo: RouteInfo) -> some View {
-    let pathParameter = resolvePathParameter(from: routeInfo)
-    let waypoint = resolveWaypoint(from: routeInfo)
-    let active = isActive(pathParameter: pathParameter, routeInfo: routeInfo)
-    let redirect = shouldRedirect(pathParameter: pathParameter, routeInfo: routeInfo)
+  public func body(info: RouteInfo) -> some View {
+    let pathParameter = resolvePathParameter(from: info)
+    let waypoint = resolveWaypoint(from: info)
+    let active = isActive(pathParameter: pathParameter, info: info)
+    let redirect = shouldRedirect(pathParameter: pathParameter, info: info)
     let nextWaypoint = pathParameter.map { waypoint.next(with: $0) } ?? waypoint
-    let info = ResolvedWaypointInfo(
+    let resolvedWaypointInfo = ResolvedWaypointInfo(
       waypoint: waypoint,
       nextWaypoint: nextWaypoint,
       pathParameter: pathParameter,
       active: active,
-      animate: routeInfo.animate,
-      completed: routeInfo.completed
+      animate: info.animate,
+      completed: info.completed
     )
     if redirect {
-      dispatch(waypoint.navigate(to: defaultPathParameter!, animate: routeInfo.animate))
-    } else if active && !routeInfo.completed && nextWaypoint.path == routeInfo.fullPath {
+      dispatch(waypoint.navigate(to: defaultPathParameter!, animate: info.animate))
+    } else if active && !info.completed && nextWaypoint.path == info.fullPath {
       dispatch(nextWaypoint.completeNavigation())
     }
-    return content(info).id(waypoint.path)
+    return content(resolvedWaypointInfo).id(waypoint.path)
   }
 
   /// Determine if the waypoint is active baed on its path parameter configuration.
@@ -71,10 +71,10 @@ public struct WaypointResolver<Content>: RouteReaderView where Content: View {
   ///
   /// - Parameters:
   ///   - pathParameter: The current path parameter.
-  ///   - routeInfo: The routing information.
+  ///   - info: The routing information.
   /// - Returns: True if the waypoint is active.
-  private func isActive(pathParameter: String?, routeInfo: RouteInfo) -> Bool {
-    routeInfo.active && (name == nil || routeInfo.component == name) && isPathParameterActive(pathParameter: pathParameter)
+  private func isActive(pathParameter: String?, info: RouteInfo) -> Bool {
+    info.active && (name == nil || info.component == name) && isPathParameterActive(pathParameter: pathParameter)
   }
 
   /// Determine if the waypoint should redirect. This occurs if the waypoint is active, but the route state is missing
@@ -82,32 +82,32 @@ public struct WaypointResolver<Content>: RouteReaderView where Content: View {
   ///
   /// - Parameters:
   ///   - pathParameter: The current path parameter.
-  ///   - routeInfo: The routing information.
+  ///   - info: The routing information.
   /// - Returns: True if it should redirect.
-  private func shouldRedirect(pathParameter: String?, routeInfo: RouteInfo) -> Bool {
-    routeInfo.active && !isPathParameterActive(pathParameter: pathParameter) && defaultPathParameter != nil
+  private func shouldRedirect(pathParameter: String?, info: RouteInfo) -> Bool {
+    info.active && !isPathParameterActive(pathParameter: pathParameter) && defaultPathParameter != nil
   }
 
   // swift-format-ignore: ValidateDocumentationComments
 
   /// Resolves the current path parameter
   ///
-  /// - Parameter routeInfo: The routing information.
+  /// - Parameter info: The routing information.
   /// - Returns: The current path parameter.
-  private func resolvePathParameter(from routeInfo: RouteInfo) -> String? {
+  private func resolvePathParameter(from info: RouteInfo) -> String? {
     guard hasPathParameter else { return nil }
-    return name == nil ? routeInfo.component : routeInfo.nextComponent
+    return name == nil ? info.component : info.nextComponent
   }
 
   /// Resolves the current waypoint for the contents of the resolver.
   ///
-  /// - Parameter routeInfo: The routing information.
+  /// - Parameter info: The routing information.
   /// - Returns: The waypoint.
-  private func resolveWaypoint(from routeInfo: RouteInfo) -> Waypoint {
+  private func resolveWaypoint(from info: RouteInfo) -> Waypoint {
     if let name = name {
-      return routeInfo.waypoint.next(with: name)
+      return info.waypoint.next(with: name)
     }
-    return routeInfo.waypoint
+    return info.waypoint
   }
 }
 


### PR DESCRIPTION
Adds the NavigationMiddleware to provide a single location where integrity checking can be performed on the navigational system. It provides two generic handlers to control the navigational system:

- `onNavigate`: Control what routes the user can access. It also allows redirecting.
- `onError`: Handle any errors that may occur. The default implementation prints the error. If a route fails to complete, it will also redirect to the root route.

Closes #6 #4